### PR TITLE
simplify guard in add_transition

### DIFF
--- a/pythomata/impl/symbolic.py
+++ b/pythomata/impl/symbolic.py
@@ -135,7 +135,7 @@ class SymbolicAutomaton(FiniteAutomaton[int, PropInt]):
             guard = simplify(parse_expr(guard))
         other_guard = self._transition_function.get(state1, {}).get(state2, None)
         if other_guard is None:
-            self._transition_function.setdefault(state1, {})[state2] = guard
+            self._transition_function.setdefault(state1, {})[state2] = simplify(guard)
         else:
             # take the OR of the two guards.
             self._transition_function[state1][state2] = simplify(other_guard | guard)

--- a/tests/test_symbolic_automaton.py
+++ b/tests/test_symbolic_automaton.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import sympy
 from hypothesis import given
 from sympy import Symbol
 from sympy.logic.boolalg import BooleanTrue
@@ -219,6 +219,34 @@ class TestDeterminize:
         assert len(self.determinized.get_successors(initial_state, {"x": True})) == 1
 
     @given(words(list("xyz"), min_size=0, max_size=2))
+    def test_accepts(self, trace):
+        """Test equivalence of acceptance between the two automata."""
+        assert self.automaton.accepts(trace) == self.determinized.accepts(trace)
+
+
+class TestDeterminize2:
+
+    @classmethod
+    def setup_class(cls):
+        A, B, C = sympy.symbols("A B C")
+        aut = SymbolicAutomaton()
+        aut.create_state()
+        aut.create_state()
+        aut.create_state()
+        aut.create_state()
+        aut.set_initial_state(3, True)
+        aut.set_final_state(0, True)
+        aut.set_final_state(1, True)
+
+        trfun = {3: {0: A | ~B, 2: B & ~A}, 0: {1: BooleanTrue()}, 2: {2: BooleanTrue()}, 1: {1: BooleanTrue()}}
+        for s in trfun:
+            for d, guard in trfun[s].items():
+                aut.add_transition(s, guard, d)
+
+        cls.automaton = aut
+        cls.determinized = aut.determinize()
+
+    @given(words(list("ABC"), min_size=0, max_size=2))
     def test_accepts(self, trace):
         """Test equivalence of acceptance between the two automata."""
         assert self.automaton.accepts(trace) == self.determinized.accepts(trace)

--- a/tests/test_symbolic_automaton.py
+++ b/tests/test_symbolic_automaton.py
@@ -225,9 +225,11 @@ class TestDeterminize:
 
 
 class TestDeterminize2:
+    """Test determinize."""
 
     @classmethod
     def setup_class(cls):
+        """Set the test up."""
         A, B, C = sympy.symbols("A B C")
         aut = SymbolicAutomaton()
         aut.create_state()


### PR DESCRIPTION
## Proposed changes

Simplify transition guard in `SymbolicAutomaton.add_transition` when it is the first transition added.

## Fixes


## Types of changes

What types of changes does your code introduce to agents-tac?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../master/CONTRIBUTING.rst) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

